### PR TITLE
Implement advanced detail view

### DIFF
--- a/pollution_data_visualizer/static/css/styles.css
+++ b/pollution_data_visualizer/static/css/styles.css
@@ -73,3 +73,17 @@ canvas {
 .progress-bar {
     transition: width 1s ease-in-out;
 }
+
+/* Offcanvas detail drawer occupies half the screen */
+#detailDrawer {
+    width: 50% !important;
+    max-width: none;
+}
+
+#detailDrawer .offcanvas-body {
+    overflow-y: auto;
+}
+
+.metric-label {
+    font-weight: bold;
+}

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -33,25 +33,47 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(`/data/history/${encodeURIComponent(city)}`)
             .then(r => r.json())
             .then(history => {
-                const canvas = document.querySelector(`canvas[data-city="${city}"]`);
-                if (!canvas) return;
-                const ctx = canvas.getContext('2d');
+                const cardCanvas = document.querySelector(`canvas[data-city="${city}"]`);
                 const labels = history.map(h => new Date(h.timestamp).toLocaleTimeString());
                 const data = history.map(h => h.aqi);
-                new Chart(ctx, {
-                    type: 'line',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'AQI',
-                            data: data,
-                            borderColor: 'rgba(75,192,192,1)',
-                            backgroundColor: 'rgba(75,192,192,0.2)',
-                            fill: true
-                        }]
-                    },
-                    options: { responsive: true, scales: { y: { beginAtZero: true } } }
-                });
+
+                if (cardCanvas) {
+                    const ctx = cardCanvas.getContext('2d');
+                    new Chart(ctx, {
+                        type: 'line',
+                        data: {
+                            labels: labels,
+                            datasets: [{
+                                label: 'AQI',
+                                data: data,
+                                borderColor: 'rgba(75,192,192,1)',
+                                backgroundColor: 'rgba(75,192,192,0.2)',
+                                fill: true
+                            }]
+                        },
+                        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+                    });
+                }
+
+                const detailCanvas = document.getElementById('historyChart');
+                if (detailCanvas) {
+                    const ctx2 = detailCanvas.getContext('2d');
+                    new Chart(ctx2, {
+                        type: 'line',
+                        data: {
+                            labels: labels,
+                            datasets: [{
+                                label: 'AQI',
+                                data: data,
+                                borderColor: 'rgba(75,192,192,1)',
+                                backgroundColor: 'rgba(75,192,192,0.2)',
+                                fill: true
+                            }]
+                        },
+                        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+                    });
+                }
+
                 updatePieChart(city, history);
             });
     }
@@ -98,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (h.aqi <= 50) counts.good++; else if (h.aqi <= 100) counts.moderate++; else counts.bad++;
         });
         const total = counts.good + counts.moderate + counts.bad;
-        const ctx = document.querySelector(`canvas[data-pie="${city}"]`).getContext('2d');
+        const ctx = document.getElementById('pieChart').getContext('2d');
         new Chart(ctx, {
             type: 'pie',
             data: {
@@ -114,8 +136,11 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('bar-bad').style.width = `${(counts.bad/total)*100}%`;
         const advice = document.querySelector('#advice');
         let text = 'Nice! Your area is not polluted.';
-        if (counts.bad > counts.moderate && counts.bad > counts.good) text = 'Your air quality is poor! Stay indoors or wear a mask!';
-        else if (counts.moderate >= counts.good && counts.moderate >= counts.bad) text = 'Consider public transport to help the environment.';
+        if (counts.bad > counts.moderate && counts.bad > counts.good) {
+            text = 'Warning! It\'s highly polluted in your area. It\'s recommended to wear a mask and stay indoors.';
+        } else if (counts.moderate >= counts.good && counts.moderate >= counts.bad) {
+            text = 'Pollution is moderate. Consider using public transport to help reduce pollution.';
+        }
         typeAdvice(text);
     }
 
@@ -137,21 +162,14 @@ document.addEventListener('DOMContentLoaded', () => {
             detailDrawer = new bootstrap.Offcanvas('#detailDrawer');
         }
         const title = document.getElementById('detailTitle');
-        const content = document.getElementById('detail-content');
         title.textContent = city;
-        content.innerHTML = `
-            <canvas data-pie="${city}"></canvas>
-            <div class="progress mt-3">
-              <div class="progress-bar bg-success" role="progressbar" id="bar-good" style="width:0%"></div>
-            </div>
-            <div class="progress mt-2">
-              <div class="progress-bar bg-warning" role="progressbar" id="bar-moderate" style="width:0%"></div>
-            </div>
-            <div class="progress mt-2">
-              <div class="progress-bar bg-danger" role="progressbar" id="bar-bad" style="width:0%"></div>
-            </div>
-            <p id="advice" class="mt-3 neon-text"></p>
-        `;
+
+        const card = document.querySelector(`[data-card="${city}"]`);
+        document.getElementById('detail-aqi').textContent = card.querySelector('.aqi').textContent;
+        document.getElementById('detail-pm25').textContent = card.querySelector('.pm25').textContent;
+        document.getElementById('detail-co').textContent = card.querySelector('.co').textContent;
+        document.getElementById('detail-no2').textContent = card.querySelector('.no2').textContent;
+
         fetchCityHistory(city);
         detailDrawer.show();
     }

--- a/pollution_data_visualizer/templates/index.html
+++ b/pollution_data_visualizer/templates/index.html
@@ -20,6 +20,32 @@
     <h5 class="offcanvas-title" id="detailTitle"></h5>
     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
-  <div class="offcanvas-body" id="detail-content"></div>
+  <div class="offcanvas-body" id="detail-content">
+    <div class="row">
+      <div class="col-md-6">
+        <canvas id="historyChart"></canvas>
+      </div>
+      <div class="col-md-6">
+        <h5>Current Metrics</h5>
+        <ul class="list-unstyled mb-3">
+          <li><span class="metric-label">AQI:</span> <span id="detail-aqi"></span></li>
+          <li><span class="metric-label">PM2.5:</span> <span id="detail-pm25"></span></li>
+          <li><span class="metric-label">CO:</span> <span id="detail-co"></span></li>
+          <li><span class="metric-label">NO2:</span> <span id="detail-no2"></span></li>
+        </ul>
+        <canvas id="pieChart"></canvas>
+        <div class="progress mt-3">
+          <div class="progress-bar bg-success" role="progressbar" id="bar-good" style="width:0%"></div>
+        </div>
+        <div class="progress mt-2">
+          <div class="progress-bar bg-warning" role="progressbar" id="bar-moderate" style="width:0%"></div>
+        </div>
+        <div class="progress mt-2">
+          <div class="progress-bar bg-danger" role="progressbar" id="bar-bad" style="width:0%"></div>
+        </div>
+        <p id="advice" class="mt-3 neon-text"></p>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand offcanvas to show detailed pollution metrics and graphs
- add CSS for half-screen detail drawer
- populate metrics in JS when opening detail drawer
- generate history and pie charts in the expanded view

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e06aeaeac8332a2e8566d494c512c