### PR TITLE
Enhance UI feedback and detail view

### DIFF
--- a/pollution_data_visualizer/static/css/styles.css
+++ b/pollution_data_visualizer/static/css/styles.css
@@ -107,7 +107,7 @@ canvas {
 
 /* Offcanvas detail drawer occupies half the screen */
 #detailDrawer {
-    width: 50% !important;
+    width: 80% !important;
     max-width: none;
 }
 
@@ -134,4 +134,23 @@ canvas {
 
 .btn-animated:active {
     transform: scale(0.95);
+}
+
+/* Toast and advice animations */
+.toast {
+    animation: fadeSlide 0.5s ease forwards;
+}
+
+@keyframes fadeSlide {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+#advice {
+    animation: fadeInScale 0.6s ease;
+}
+
+@keyframes fadeInScale {
+    from { opacity: 0; transform: scale(0.9); }
+    to { opacity: 1; transform: scale(1); }
 }

--- a/pollution_data_visualizer/templates/base.html
+++ b/pollution_data_visualizer/templates/base.html
@@ -49,6 +49,9 @@
 
 {% block content %}{% endblock %}
 
+<!-- Toast container for status messages -->
+<div id="toast-container" class="position-fixed top-0 end-0 p-3" style="z-index:1100"></div>
+
 <script src="{{ url_for('static', filename='js/suggestions.js') }}"></script>
 <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>

--- a/pollution_data_visualizer/templates/index.html
+++ b/pollution_data_visualizer/templates/index.html
@@ -46,6 +46,7 @@
       </div>
       <div class="col-md-6">
         <h5>Current Metrics</h5>
+        <p id="advice" class="neon-text mb-3"></p>
         <ul class="list-unstyled mb-3">
           <li class="metric-item" data-bs-toggle="tooltip" title="Air Quality Index">
             <span class="metric-label">AQI:</span> <span id="detail-aqi"></span>
@@ -71,7 +72,7 @@
         <div class="progress mt-2">
           <div class="progress-bar bg-danger" role="progressbar" id="bar-bad" style="width:0%"></div>
         </div>
-        <p id="advice" class="mt-3 neon-text"></p>
+        <button type="button" class="btn btn-secondary mt-3" data-bs-dismiss="offcanvas">Close</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enlarge offcanvas detail drawer and move advice message to the top
- add toast container in base template
- animate toast messages and advice
- add loading/done notifications with smooth scrolling for searched cities
- remove initial auto-scroll of default cards

## Testing
- `pip install -r pollution_data_visualizer/requirements.txt`
- `pytest -q`
- `npm install --silent`
- `npm test --silent`
- `npx jest tests_js --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_686e35c05094833295e798725a9ad704