### PR TITLE
Add CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,35 @@
+name: CD
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: pollution_data_visualizer
+          file: pollution_data_visualizer/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ Use pytest to run the test suite:
 PYTHONPATH=. pytest -q
 ```
 
+
+## Continuous Integration and Delivery
+This repository uses GitHub Actions for automated testing and delivery.
+The `ci.yml` workflow runs unit and integration tests for both Python and JavaScript
+and builds the Docker image. The `cd.yml` workflow pushes the built image
+to GitHub Container Registry whenever changes land on the `main` branch.
+


### PR DESCRIPTION
## Summary
- add a CD workflow to push Docker images to GHCR
- document CI and CD in README

## Testing
- `npm test --silent`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e39a74a848332b7dc590c3fae6b01