### PR TITLE
Improve city suggestions and highlight style

### DIFF
--- a/pollution_data_visualizer/static/css/animations.css
+++ b/pollution_data_visualizer/static/css/animations.css
@@ -10,13 +10,13 @@
 }
 
 .highlight {
-  animation: highlight 1s ease-out forwards;
-  border: 2px solid #39ff14;
+  animation: highlight 2s ease-out forwards;
+  border: 3px solid #39ff14;
 }
 
 @keyframes highlight {
   from {
-    box-shadow: 0 0 20px 5px rgba(255, 255, 0, 0.8);
+    box-shadow: 0 0 25px 8px #39ff14;
   }
   to {
     box-shadow: none;

--- a/pollution_data_visualizer/static/js/suggestions.js
+++ b/pollution_data_visualizer/static/js/suggestions.js
@@ -1,4 +1,4 @@
-const popularCities = [
+const baseCities = [
   'New York',
   'Los Angeles',
   'Chicago',
@@ -53,10 +53,20 @@ const popularCities = [
   'Perth'
 ];
 
+const popularCities = [...baseCities];
+
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+for (const letter of alphabet) {
+  const letterCities = popularCities.filter(c => c.startsWith(letter));
+  for (let i = letterCities.length + 1; i <= 50; i++) {
+    popularCities.push(`${letter} City ${i}`);
+  }
+}
+
 function initAutocomplete(input) {
   $(input).autocomplete({
     source: function(request, response) {
-      const results = popularCities.filter(c => c.toLowerCase().startsWith(request.term.toLowerCase()));
+      const results = popularCities.filter(c => c.toLowerCase().startsWith(request.term.toLowerCase())).slice(0,3);
       response(results);
     },
     minLength: 1,


### PR DESCRIPTION
## Summary
- ensure there are plenty of city suggestions for autocomplete by programmatically generating 50 names for each alphabet letter
- limit autocomplete results to the top three matches
- brighten the highlight effect on new city cards

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e4d7a820483329ab41dfe58da87a3