### PR TITLE
Improve comparison and profile features

### DIFF
--- a/pollution_data_visualizer/static/js/profile.js
+++ b/pollution_data_visualizer/static/js/profile.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.remove-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const city = btn.dataset.city;
+      fetch('/api/favorites', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ city })
+      }).then(() => btn.closest('tr').remove());
+    });
+  });
+  document.getElementById('saveFavs').addEventListener('click', (e) => {
+    e.preventDefault();
+    document.querySelectorAll('#favorites-body tr').forEach(row => {
+      const city = row.dataset.city;
+      const alertVal = row.querySelector('.alert-input').value;
+      fetch('/api/favorites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ city, alert: parseInt(alertVal,10) })
+      });
+    });
+    showToast('Saved', 'success', 3000);
+  });
+});

--- a/pollution_data_visualizer/templates/base.html
+++ b/pollution_data_visualizer/templates/base.html
@@ -31,6 +31,7 @@
         </li>
         {% if user %}
         <li class="nav-item text-white mt-2 me-3">Hello, {{ user.username }}</li>
+        <li class="nav-item"><a class="nav-link" href="/profile">Profile</a></li>
         <li class="nav-item">
           <a class="nav-link" href="/logout">Logout</a>
         </li>

--- a/pollution_data_visualizer/templates/index.html
+++ b/pollution_data_visualizer/templates/index.html
@@ -27,6 +27,7 @@
       </div>
       <div class="modal-body">
         <canvas id="compareChart"></canvas>
+        <canvas id="comparePollutantChart" class="mt-4"></canvas>
       </div>
     </div>
   </div>

--- a/pollution_data_visualizer/templates/profile.html
+++ b/pollution_data_visualizer/templates/profile.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container">
+  <h1 class="mb-4">Profile</h1>
+  <form method="post">
+    <table class="table">
+      <thead><tr><th>City</th><th>Alert Threshold</th><th>Remove</th></tr></thead>
+      <tbody id="favorites-body">
+      {% for fav in user.favorites %}
+      <tr data-city="{{ fav.city }}">
+        <td>{{ fav.city }}</td>
+        <td><input type="number" name="alert_{{ fav.city }}" class="form-control alert-input" value="{{ fav.alert or 150 }}"></td>
+        <td><button type="button" class="btn btn-danger remove-btn" data-city="{{ fav.city }}">Remove</button></td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    <button id="saveFavs" type="submit" class="btn btn-primary btn-animated">Save Changes</button>
+  </form>
+</div>
+<script src="{{ url_for('static', filename='js/profile.js') }}"></script>
+{% endblock %}

--- a/pollution_data_visualizer/tests/test_app.py
+++ b/pollution_data_visualizer/tests/test_app.py
@@ -31,6 +31,14 @@ class TestApp(unittest.TestCase):
         response = self.app.get('/api/favorites')
         self.assertEqual(response.status_code, 401)
 
+    def test_profile_requires_login(self):
+        response = self.app.get('/profile')
+        self.assertEqual(response.status_code, 302)
+
+    def test_coords_endpoint(self):
+        response = self.app.get('/api/coords/New%20York')
+        self.assertIn(response.status_code, [200, 404])
+
     def test_metrics_endpoint(self):
         response = self.app.get('/metrics')
         self.assertEqual(response.status_code, 200)

--- a/pollution_data_visualizer/tests/test_e2e.py
+++ b/pollution_data_visualizer/tests/test_e2e.py
@@ -38,7 +38,8 @@ class TestE2E(unittest.TestCase):
         self.assertEqual(data['status'], 'saved')
         list_resp = self.client.get('/api/favorites')
         self.assertEqual(list_resp.status_code, 200)
-        self.assertIn('DemoCity', list_resp.get_json()['favorites'])
+        cities = [f['city'] for f in list_resp.get_json()['favorites']]
+        self.assertIn('DemoCity', cities)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle alert thresholds in `/api/favorites`
- add `/profile` page and script to manage favourite cities
- update navbar with profile link
- support pollutant comparison bar chart
- notify when AQI exceeds threshold and open details from map markers
- create JS for profile management and enlarge suggestion list
- update tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e53cd65bc833288d57de18ff37812