### PR TITLE
Fix search input freeze and improve success toast

### DIFF
--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -179,7 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (scroll) {
                 card.scrollIntoView({ behavior: 'smooth' });
-                showToast('Done!', 'success', 4000);
+                showToast(`Done! See the pollution levels for ${city}`, 'success', 4000);
             }
         } else {
             card.querySelector('.aqi').textContent = data.aqi;
@@ -349,9 +349,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!city) return;
         searchInput.disabled = true;
         showLoading(city);
+        const enableTimer = setTimeout(() => {
+            searchInput.disabled = false;
+        }, 12000);
         try {
             await fetchCityData(city, true);
         } finally {
+            clearTimeout(enableTimer);
             hideLoading();
             searchInput.disabled = false;
             searchInput.value = '';


### PR DESCRIPTION
## Summary
- ensure the city card toast includes the searched city
- automatically re‑enable the search box if a request stalls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_686e6aa7fef48332acf6a4ab78df32f8