### PR TITLE
Add WAQI widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The interface uses Bootstrap together with Tailwind CSS for a modern look. Globa
 - Tailwind CSS styling with gradient hero section and animated typewriter heading.
 - Animated line and pie charts that update smoothly with a toggle to switch chart type.
 - Real-time updates using WebSockets so cards refresh automatically.
+- Embedded AQI widgets from WAQI display live readings on each city card.
 - Interactive world map shows cities with markers.
 - Autocomplete search with jQuery UI.
 - Color-coded map markers based on AQI levels.

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -144,6 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderCityCard(city, data, scroll) {
+        const slug = city.toLowerCase().replace(/\s+/g, '');
         let card = document.querySelector(`[data-card="${city}"]`);
         if (!card) {
             const col = document.createElement('div');
@@ -162,6 +163,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         <p class="small">PM2.5: <span class="pm25">${data.pm25 ?? 'N/A'}</span></p>
                         <p class="small">CO: <span class="co">${data.co ?? 'N/A'}</span></p>
                         <p class="small">NO2: <span class="no2">${data.no2 ?? 'N/A'}</span></p>
+                        <div id="widget-${slug}" class="mb-2"></div>
                         <canvas data-city="${city}"></canvas>
                     </div>
                 </div>`;
@@ -180,6 +182,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (scroll) {
                 card.scrollIntoView({ behavior: 'smooth' });
                 showToast(`Done! See the pollution levels for ${city}`, 'success', 4000);
+            }
+            if (typeof _aqiFeed === 'function') {
+                _aqiFeed({ container: `widget-${slug}`, city: slug });
             }
         } else {
             card.querySelector('.aqi').textContent = data.aqi;

--- a/pollution_data_visualizer/templates/base.html
+++ b/pollution_data_visualizer/templates/base.html
@@ -16,6 +16,21 @@
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+    <script type="text/javascript" charset="utf-8">
+        (function (w, d, t, f) {
+            w[f] = w[f] || function (c, k, n) {
+                s = w[f];
+                k = s['k'] = (s['k'] || (k ? ('&k=' + k) : ''));
+                s['c'] = c = (c instanceof Array) ? c : [c];
+                s['n'] = n = n || 0;
+                L = d.createElement(t);
+                e = d.getElementsByTagName(t)[0];
+                L.async = 1;
+                L.src = '//feed.aqicn.org/feed/' + (c[n].city) + '/' + (c[n].lang || '') + '/feed.v1.js?n=' + n + k;
+                e.parentNode.insertBefore(L, e);
+            };
+        })(window, document, 'script', '_aqiFeed');
+    </script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">


### PR DESCRIPTION
## Summary
- integrate WAQI widget script in base template
- embed a widget container in every city card and load the widget
- document widget feature in README

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e88d781b08332b7515ed4af445cee