### PR TITLE
Fix map markers when data fetch fails

### DIFF
--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -84,6 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 console.error(err);
                 document.getElementById('loading').style.display = 'none';
                 showToast('Failed to fetch data for ' + city, 'danger', 4000);
+                fetchCoords(city, null);
             });
     }
 
@@ -479,6 +480,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     cities.forEach(city => {
+        fetchCoords(city, null);
         fetchCityData(city, false);
         setInterval(() => fetchCityData(city), 1800000);
     });


### PR DESCRIPTION
## Summary
- ensure city markers load even if `/data/<city>` fails
- show markers immediately on startup

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e912b7d988332a6e90a57f9ebf520