### PR TITLE
Improve marker handling and persistent database

### DIFF
--- a/pollution_data_visualizer/config.py
+++ b/pollution_data_visualizer/config.py
@@ -10,5 +10,6 @@ class Config:
     
     # Database Configuration (For Local Testing, PostgreSQL can be hosted on Heroku)
     # Use a lightweight SQLite database by default for easier local setup.
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///pollution.db')
+    db_path = os.path.join(os.path.dirname(__file__), 'pollution.db')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///' + db_path)
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -73,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(data => {
                 if (data.error) {
                     console.error(data.error);
+                    fetchCoords(city, null);
                     document.getElementById('loading').style.display = 'none';
                     return;
                 }


### PR DESCRIPTION
## Summary
- fix map markers when data retrieval returns an error
- store the SQLite database in a fixed location to preserve history

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e9422717083328a3e8b47ca3e7816