### PR TITLE
Fix map markers for all cities

### DIFF
--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -184,6 +184,15 @@ def api_coords(city):
         pass
     return jsonify({'error': 'Unknown city'}), 404
 
+# Return all known coordinates
+@app.route('/api/all_coords')
+def api_all_coords():
+    import json, os
+    path = os.path.join(os.path.dirname(__file__), 'city_coords.json')
+    with open(path) as f:
+        coords = json.load(f)
+    return jsonify(coords)
+
 # Expose metrics for monitoring
 @app.route('/metrics')
 def metrics():

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -465,6 +465,20 @@ document.addEventListener('DOMContentLoaded', () => {
         fetchCoords(data.city, data.aqi);
     });
 
+    function initMarkers() {
+        fetch('/api/all_coords')
+            .then(r => r.json())
+            .then(coordMap => {
+                cities.forEach(city => {
+                    const coords = coordMap[city];
+                    if (coords && !markers[city]) {
+                        markers[city] = L.circleMarker([coords[0], coords[1]], {color: markerColor(null)}).addTo(map).bindPopup(`${city} AQI: N/A`);
+                        markers[city].on('click', () => openDetail(city));
+                    }
+                });
+            });
+    }
+
     function fetchCoords(city, aqi) {
         fetch(`/api/coords/${encodeURIComponent(city)}`)
             .then(r => r.json())
@@ -480,6 +494,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }
 
+    initMarkers();
     cities.forEach(city => {
         fetchCoords(city, null);
         fetchCityData(city, false);

--- a/pollution_data_visualizer/tests/test_app.py
+++ b/pollution_data_visualizer/tests/test_app.py
@@ -43,6 +43,12 @@ class TestApp(unittest.TestCase):
         resp = self.app.get('/api/coords/Perth')
         self.assertIn(resp.status_code, [200, 404])
 
+    def test_all_coords(self):
+        resp = self.app.get('/api/all_coords')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn('New York', data)
+
     def test_metrics_endpoint(self):
         response = self.app.get('/metrics')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- add `/api/all_coords` endpoint for retrieving all city coordinates
- initialize Leaflet markers using all coordinates
- test new endpoint

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e988bd0ec8332be1b6c15d9abfe25