### PR TITLE
Fix API fetch with encoded city names

### DIFF
--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -172,7 +172,8 @@ def api_coords(city):
     if city in coords:
         return jsonify({'lat': coords[city][0], 'lon': coords[city][1]})
     try:
-        resp = requests.get(Config.BASE_URL.format(city), timeout=10)
+        from urllib.parse import quote
+        resp = requests.get(Config.BASE_URL.format(quote(city)), timeout=10)
         data = resp.json()
         if data.get('status') == 'ok':
             lat, lon = data['data']['city']['geo']

--- a/pollution_data_visualizer/data_collector.py
+++ b/pollution_data_visualizer/data_collector.py
@@ -1,11 +1,12 @@
 import requests
 from config import Config
+from urllib.parse import quote
 from datetime import datetime, timedelta
 from models import db, AirQualityData
 
 # Function to fetch air quality data from AQICN API
 def fetch_air_quality(city):
-    url = Config.BASE_URL.format(city)
+    url = Config.BASE_URL.format(quote(city))
     response = requests.get(url)
     data = response.json()
 


### PR DESCRIPTION
## Summary
- percent encode city names when requesting external API
- percent encode names for `/api/coords/<city>`

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686ea92e87c883329ecf9a5d6726fea4