### PR TITLE
Fix map markers and socketio broadcast

### DIFF
--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -46,7 +46,7 @@ def scheduled_collection():
                 collect_data(city)
                 history = get_aqi_history(city, hours=1)
                 if history:
-                    socketio.emit('update', {'city': city, **history[-1]}, broadcast=True)
+                    socketio.emit('update', {'city': city, **history[-1]})
                     publish_event('aqi_collected', {'city': city, 'aqi': history[-1]['aqi']})
             except Exception as e:
                 app.logger.warning("Failed to collect data for %s: %s", city, e)
@@ -137,7 +137,7 @@ def search():
             monitored_cities.append(city)
         history = get_aqi_history(city, hours=1)
         if history:
-            socketio.emit('update', {'city': city, **history[-1]}, broadcast=True)
+            socketio.emit('update', {'city': city, **history[-1]})
         publish_event('search_city', {'city': city})
         recent_aqi = get_recent_aqi(city)
         return render_template('index.html', city=city, aqi=recent_aqi)

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('theme-toggle');
     const compareBtn = document.getElementById('compareBtn');
     let savedCities = JSON.parse(localStorage.getItem('savedCities') || '[]');
+    let searchedCities = [];
     const alerts = JSON.parse(localStorage.getItem('alerts') || '{}');
     let chartType = 'line';
     let detailChart = null;
@@ -63,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!cities.includes(city)) {
             cities.push(city);
             setInterval(() => fetchCityData(city), 1800000);
+            searchedCities.push(city);
         }
     }
 
@@ -477,7 +479,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch('/api/all_coords')
             .then(r => r.json())
             .then(coordMap => {
-                cities.forEach(city => {
+                [...cities, ...searchedCities].forEach(city => {
                     const coords = coordMap[city];
                     if (coords && !markers[city]) {
                         markers[city] = L.circleMarker([coords[0], coords[1]], {color: markerColor(null)}).addTo(map).bindPopup(`${city} AQI: N/A`);

--- a/pollution_data_visualizer/tests/test_app.py
+++ b/pollution_data_visualizer/tests/test_app.py
@@ -48,6 +48,7 @@ class TestApp(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         data = resp.get_json()
         self.assertIn('New York', data)
+        self.assertIn('Paris', data)
 
     def test_metrics_endpoint(self):
         response = self.app.get('/metrics')


### PR DESCRIPTION
## Summary
- remove deprecated `broadcast` parameter from server emits
- track searched cities and initialize markers properly
- test that `/api/all_coords` contains Paris

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686eae0aeebc8332acc2f152e072ac23