### PR TITLE
Remove WAQI widgets and persist startup records

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The interface uses Bootstrap together with Tailwind CSS for a modern look. Globa
 - Tailwind CSS styling with gradient hero section and animated typewriter heading.
 - Animated line and pie charts that update smoothly with a toggle to switch chart type.
 - Real-time updates using WebSockets so cards refresh automatically.
-- Embedded AQI widgets from WAQI display live readings on each city card.
 - Interactive world map shows cities with markers.
 - Autocomplete search with jQuery UI.
 - Color-coded map markers based on AQI levels.

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }).addTo(map);
     const markers = {};
     let loadingToast = null;
-    let widgetConfigs = [];
 
     function showToast(message, type='info', delay=4000, autohide=true) {
         const container = document.getElementById('toast-container');
@@ -175,7 +174,6 @@ document.addEventListener('DOMContentLoaded', () => {
                         <p class="small">PM2.5: <span class="pm25">${data.pm25 ?? 'N/A'}</span></p>
                         <p class="small">CO: <span class="co">${data.co ?? 'N/A'}</span></p>
                         <p class="small">NO2: <span class="no2">${data.no2 ?? 'N/A'}</span></p>
-                        <div id="widget-${slug}" class="mb-2"></div>
                         <canvas data-city="${city}"></canvas>
                     </div>
                 </div>`;
@@ -194,10 +192,6 @@ document.addEventListener('DOMContentLoaded', () => {
             if (scroll) {
                 card.scrollIntoView({ behavior: 'smooth' });
                 showToast(`Done! See the pollution levels for ${city}`, 'success', 4000);
-            }
-            if (typeof _aqiFeed === 'function') {
-                widgetConfigs.push({ container: `widget-${slug}`, city: slug });
-                _aqiFeed(widgetConfigs, null, widgetConfigs.length - 1);
             }
         } else {
             card.querySelector('.aqi').textContent = data.aqi;

--- a/pollution_data_visualizer/templates/base.html
+++ b/pollution_data_visualizer/templates/base.html
@@ -16,21 +16,6 @@
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
-    <script type="text/javascript" charset="utf-8">
-        (function (w, d, t, f) {
-            w[f] = w[f] || function (c, k, n) {
-                s = w[f];
-                k = s['k'] = (s['k'] || (k ? ('&k=' + k) : ''));
-                s['c'] = c = (c instanceof Array) ? c : [c];
-                s['n'] = n = n || 0;
-                L = d.createElement(t);
-                e = d.getElementsByTagName(t)[0];
-                L.async = 1;
-                L.src = '//feed.aqicn.org/feed/' + (c[n].city) + '/' + (c[n].lang || '') + '/feed.v1.js?n=' + n + k;
-                e.parentNode.insertBefore(L, e);
-            };
-        })(window, document, 'script', '_aqiFeed');
-    </script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">


### PR DESCRIPTION
## Summary
- remove WAQI widget loader and widget containers
- collect AQI data at startup regardless of previous records

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686eb651b41083329dd20dedb3131477