### PR TITLE
Add TTL and rate limit tests, update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,12 @@ jobs:
       - name: Run JS tests
         run: npm test
 
-      - name: Build Docker image for smoke test
-        run: docker build -t pollution_app_test .
+      - name: Build Docker image
+        run: docker build -t pollution_test .
       - name: Smoke test container
         run: |
-          docker run -d --name test_cont -e WAQI_TOKEN=dummy -e SECRET_KEY=secret -p 8080:8080 pollution_app_test
+          docker run -d --name test_cont \
+            -e WAQI_TOKEN=dummy -e SECRET_KEY=secret -p8080:8080 pollution_test
           sleep 5
           curl -f http://localhost:8080/data/current?city=beijing
           curl -f http://localhost:8080/data/history

--- a/pollution_data_visualizer/tests/test_cache.py
+++ b/pollution_data_visualizer/tests/test_cache.py
@@ -1,5 +1,10 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from config import Config
 from data_collector import fetch_air_quality, _cache
 
@@ -17,3 +22,33 @@ class TestCache(unittest.TestCase):
         mock_get.reset_mock()
         fetch_air_quality(city)
         mock_get.assert_not_called()
+
+    @patch('data_collector.requests.get')
+    def test_ttl_default_city(self, mock_get):
+        from cachetools import TTLCache
+
+        # custom timer to control time progression
+        t = [0]
+
+        def timer():
+            return t[0]
+
+        cache = TTLCache(maxsize=64, ttl=300, timer=timer)
+        with patch('data_collector._cache', cache):
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {'status': 'ok', 'data': {'aqi': 1, 'iaqi': {}}}
+            city = Config.DEFAULT_CITIES[0]
+
+            # first call populates cache
+            fetch_air_quality(city)
+            mock_get.assert_called_once()
+            mock_get.reset_mock()
+
+            # within ttl should use cache
+            fetch_air_quality(city)
+            mock_get.assert_not_called()
+
+            # advance time beyond ttl
+            t[0] += 301
+            fetch_air_quality(city)
+            mock_get.assert_called_once()

--- a/pollution_data_visualizer/tests/test_rate_limiter.py
+++ b/pollution_data_visualizer/tests/test_rate_limiter.py
@@ -1,12 +1,22 @@
+import os
+import sys
 import time
 import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from data_collector import TokenBucket
 
 class TestRateLimiter(unittest.TestCase):
     def test_burst_and_rate(self):
         bucket = TokenBucket(16, 60)
+        # acquiring up to burst size should not block
+        start = time.time()
         for _ in range(60):
             bucket.acquire()
+        self.assertLess(time.time() - start, 0.5)
+
+        # next acquire should respect rate limit
         start = time.time()
         bucket.acquire()
-        self.assertGreaterEqual(time.time() - start, 1/16)
+        self.assertGreaterEqual(time.time() - start, 1 / 16)


### PR DESCRIPTION
## Summary
- include JS static tests via jest
- verify rate limiter burst and rate behavior
- ensure caching TTL works for default cities
- run JS tests and add Docker smoke test in CI

## Testing
- `npm test`
- `WAQI_TOKEN=dummy SECRET_KEY=test PYTHONPATH=. pytest pollution_data_visualizer/tests/test_rate_limiter.py pollution_data_visualizer/tests/test_cache.py -q`
- `flake8 pollution_data_visualizer` *(fails: E/W/F issues)*
- `docker build -t pollution_test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687121cd6b9c833394dc97874d632d39