### PR TITLE
Add Prometheus metrics and alert rules

### DIFF
--- a/cloud_function.py
+++ b/cloud_function.py
@@ -1,6 +1,7 @@
-from pollution_data_visualizer.app import collect_all_data
+from pollution_data_visualizer.app import collect_all_data, TASKS_COLLECT_CALLED
 
 def run(event, context):
     """Entry point for Pub/Sub triggered Cloud Function."""
+    TASKS_COLLECT_CALLED.inc()
     collect_all_data(force=True)
     return 'ok'

--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -21,10 +21,11 @@ db.init_app(app)
 socketio = SocketIO(app, async_mode='eventlet')
 app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {'/metrics': make_wsgi_app()})
 
-REQUEST_COUNT = Counter('request_count', 'Total HTTP requests', ['method', 'endpoint', 'status'])
+REQUEST_COUNT = Counter('http_requests_total', 'Total HTTP requests', ['method', 'endpoint', 'status'])
 ERROR_COUNT = Counter('http_errors_total', 'HTTP error responses', ['endpoint', 'status'])
 AQI_GAUGE = Gauge('stored_aqi_records', 'Number of AQI records in the database')
 SCHEDULER_LAST_RUN = Gauge('aqi_job_last_run_seconds', 'Time of last collection run')
+TASKS_COLLECT_CALLED = Counter('tasks_collect_called_total', 'Times the collection task has been triggered')
 
 def _log_event(event):
     app.logger.info('event: %s', event)
@@ -220,6 +221,7 @@ def api_all_coords():
 
 @app.route('/tasks/collect', methods=['POST'])
 def trigger_collect():
+    TASKS_COLLECT_CALLED.inc()
     collect_all_data(force=True)
     return '', 204
 

--- a/pollution_data_visualizer/cloud_function.py
+++ b/pollution_data_visualizer/cloud_function.py
@@ -1,5 +1,6 @@
-from pollution_data_visualizer.app import collect_all_data
+from pollution_data_visualizer.app import collect_all_data, TASKS_COLLECT_CALLED
 
 def pubsub_collect(event, context):
+    TASKS_COLLECT_CALLED.inc()
     collect_all_data(force=True)
     return 'ok'

--- a/prometheus/alert.rules.yml
+++ b/prometheus/alert.rules.yml
@@ -1,17 +1,13 @@
 groups:
-- name: aqi-alerts
-  rules:
-  - alert: HighHttpErrorRate
-    expr: sum(rate(http_errors_total[5m])) / sum(rate(request_count_total[5m])) > 0.05
-    for: 5m
-    labels:
-      severity: high
-    annotations:
-      description: HTTP error rate greater than 5% over 5 minutes
-  - alert: SchedulerMissedRuns
-    expr: increase(request_count_total{endpoint="/tasks/collect"}[60m]) == 0
-    for: 60m
-    labels:
-      severity: critical
-    annotations:
-      description: No /tasks/collect calls in the last hour
+  - name: high_error_rate
+    rules:
+      - alert: HighHttpErrorRate
+        expr: rate(http_errors_total[5m]) / rate(http_requests_total[5m]) > 0.05
+        for: 5m
+        labels: {severity: critical}
+  - name: scheduler_missed_runs
+    rules:
+      - alert: SchedulerMissedRuns
+        expr: increase(tasks_collect_called_total[60m]) < 2
+        for: 10m
+        labels: {severity: warning}


### PR DESCRIPTION
## Summary
- expose `/metrics` (already in `app.py`) and add metrics counters
- increment scheduled task counter from cloud functions and HTTP route
- rename `request_count` metric to `http_requests_total`
- add Prometheus alert rules for error rate and scheduler runs

## Testing
- `flake8 pollution_data_visualizer`
- `PYTHONPATH=. pytest -k "not end_to_end" -q`
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68712442ff5483339f3005f4352eba32