### PR TITLE
Add data proxy route

### DIFF
--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -215,3 +215,8 @@ if __name__ == "__main__":
         port=port,
         allow_unsafe_werkzeug=True
     )
+
+@app.route('/data/<city>')
+def data_proxy(city):
+    # updated for backward compatibility: proxy to history endpoint
+    return get_history()


### PR DESCRIPTION
## Summary
- add missing `/data/<city>` proxy for backwards compatibility

## Testing
- `pytest -q`
- `npm test --silent` *(shows 0 tests)*

------
https://chatgpt.com/codex/tasks/task_b_6871549b239c83338e76d1dfe51fb990