### PR TITLE
Fix data retrieval with WAQI API

### DIFF
--- a/pollution_data_visualizer/config.py
+++ b/pollution_data_visualizer/config.py
@@ -2,7 +2,7 @@ import os
 
 class Config:
     API_KEY = 'da422a944c1edaa853351550b87c87b02b7563ab'
-    BASE_URL = 'https://api.openaq.org/v3/measurements'  # updated to OpenAQ v3
+    BASE_URL = 'https://api.waqi.info/feed/{city}/'
 
     FETCH_CACHE_MINUTES = 30
     


### PR DESCRIPTION
## Summary
- pull air quality data from WAQI API rather than OpenAQ
- configure BASE_URL for WAQI feed

## Testing
- `pytest -q`
- `curl http://127.0.0.1:5050/data/Los%20Angeles | head`

------
https://chatgpt.com/codex/tasks/task_b_687210cbe5e8833389e00129c5d95794