### PR TITLE
Improve timezone handling for city timestamps

### DIFF
--- a/pollution_data_visualizer/app.py
+++ b/pollution_data_visualizer/app.py
@@ -93,7 +93,7 @@ def get_city_data(city):
             'location': m.location,
             'value': m.value,
             'unit': m.unit,
-            'utc_datetime': m.utc_datetime.isoformat()
+            'utc_datetime': m.utc_datetime.isoformat() + 'Z'
         } for m in records
     ])
 
@@ -117,7 +117,7 @@ def history():
                .all())  # updated to OpenAQ v3
     return jsonify([
         {
-            'utc_datetime': m.utc_datetime.isoformat(),
+            'utc_datetime': m.utc_datetime.isoformat() + 'Z',
             'value': m.value,
             'unit': m.unit,
             'location': m.location

--- a/pollution_data_visualizer/data_analyzer.py
+++ b/pollution_data_visualizer/data_analyzer.py
@@ -26,7 +26,7 @@ def get_aqi_history(city, hours=24):
     )
     return [
         {
-            "timestamp": record.timestamp.isoformat(),
+            "timestamp": record.timestamp.isoformat() + "Z",
             "aqi": record.aqi,
             "pm25": record.pm25,
             "co": record.co,

--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 const latest = history[history.length - 1] || {};
                 renderCityCard(city, latest, scroll); // updated to match database schema
-                fetchCoords(city, latest.value);
+                if (!cityTimezones[city]) fetchCoords(city, latest.value);
                 document.getElementById('loading').style.display = 'none';
             })
             .catch(err => {
@@ -484,6 +484,7 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(r => r.json())
             .then(coords => {
                 if (coords.error) return;
+                const first = !cityTimezones[city];
                 cityTimezones[city] = coords.tz || 'UTC';
                 if (markers[city]) {
                     markers[city].setLatLng([coords.lat, coords.lon]);
@@ -492,6 +493,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     markers[city] = L.circleMarker([coords.lat, coords.lon], {color: markerColor(aqi)}).addTo(map).bindPopup(`${city} AQI: ${aqi}`);
                     markers[city].on('click', () => openDetail(city));
                 }
+                if (first) fetchCityData(city, false);
             });
     }
 


### PR DESCRIPTION
## Summary
- append `Z` to UTC datetimes so the frontend recognizes them as UTC
- refresh city data after fetching timezones to display local times

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872344d9a1483339b64be2902c32c1d