### PR TITLE
Fix AQI marker colors and messages

### DIFF
--- a/pollution_data_visualizer/static/js/app.js
+++ b/pollution_data_visualizer/static/js/app.js
@@ -249,14 +249,8 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('bar-bad').style.width = `${(counts.bad/total)*100}%`;
         const advice = document.querySelector('#advice');
         const latest = history[history.length - 1]?.value || 0; // updated to match database schema
-        let text = 'Nice! Your area is not polluted.';
-        advice.classList.remove('neon-warning');
-        if (latest > 100) {
-            text = 'Warning! It\'s highly polluted in your area. It\'s recommended to wear a mask and stay indoors.';
-            advice.classList.add('neon-warning');
-        } else if (latest > 50) {
-            text = 'Pollution is moderate. Consider using public transport to help reduce pollution.';
-        }
+        const text = aqiMessage(latest);
+        if (latest > 100) advice.classList.add('neon-warning'); else advice.classList.remove('neon-warning');
         typeAdvice(text);
     }
 
@@ -321,6 +315,16 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             element.textContent = current.toFixed(0);
         }, 20);
+    }
+
+    function aqiMessage(aqi){
+        if (aqi == null) return 'Air quality data unavailable.';
+        if (aqi > 300) return 'Health warning of emergency conditions: everyone is more likely to be affected.';
+        if (aqi > 200) return 'Health alert: The risk of health effects is increased for everyone.';
+        if (aqi > 150) return 'Some members of the general public may experience health effects; members of sensitive groups may experience more serious health effects.';
+        if (aqi > 100) return 'Members of sensitive groups may experience health effects. The general public is less likely to be affected.';
+        if (aqi > 50) return 'Air quality is acceptable. However, there may be a risk for some people, particularly those who are unusually sensitive to air pollution.';
+        return 'Air quality is satisfactory, and air pollution poses little or no risk.';
     }
 
     function typeAdvice(text) {

--- a/pollution_data_visualizer/static/js/utils.js
+++ b/pollution_data_visualizer/static/js/utils.js
@@ -1,8 +1,12 @@
 (function(global){
   function markerColor(aqi){
+    if(aqi == null) return 'gray';
     if (aqi <= 50) return 'green';
     if (aqi <= 100) return 'yellow';
-    return 'red';
+    if (aqi <= 150) return 'orange';
+    if (aqi <= 200) return 'red';
+    if (aqi <= 300) return 'purple';
+    return 'maroon';
   }
   if (typeof module !== 'undefined' && module.exports){
     module.exports.markerColor = markerColor;


### PR DESCRIPTION
## Summary
- refine `markerColor` utility to cover six AQI ranges
- add `aqiMessage` helper and use for detail advice
- update detail logic to set warning style when AQI > 100

## Testing
- `npm install`
- `npx jest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68723eb15e948333bf0b266a2b233fc1